### PR TITLE
Update version in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ is in the works, check it out, to follow how it is progressing.
 Inky is available on Hex. Add inky to your mix.exs deps:
 
 ```elixir
-{:inky, "~> 1.0.0"},
+{:inky, "~> 1.0.1"},
 ```
 
 Run `mix deps.get` to get the new dep.


### PR DESCRIPTION
I got stuck (with the wHAT) not working, before realising that 1.0.1 was the latest version and included a fix for the wHAT. This updates the Readme so hopefully others don't hit that issue as well. 