### PR TITLE
Add explicit @type t() definition to Inky.Display

### DIFF
--- a/lib/display/display.ex
+++ b/lib/display/display.ex
@@ -4,6 +4,8 @@ defmodule Inky.Display do
   """
 
   alias Inky.LookupTables
+  
+  @type t() :: %__MODULE__{}
 
   @enforce_keys [:type, :width, :height, :packed_dimensions, :rotation, :accent, :luts]
   defstruct type: nil,


### PR DESCRIPTION
# What does this PR do?

It adds an explicit type definition to Inky.Display.

# Why was this PR needed?

Inky would fail to compile with Elixir 1.10.1 with the error:

```
== Compilation error in file lib/display/display.ex ==
** (CompileError) lib/display/display.ex:17: type t/0 undefined (no such type in Inky.Display)
    (elixir 1.10.1) lib/kernel/typespec.ex:898: Kernel.Typespec.compile_error/2
    (elixir 1.10.1) lib/kernel/typespec.ex:937: Kernel.Typespec.fn_args/6
    (elixir 1.10.1) lib/kernel/typespec.ex:377: Kernel.Typespec.translate_spec/8
    (stdlib 3.11.2) lists.erl:1354: :lists.mapfoldl/3
    (elixir 1.10.1) lib/kernel/typespec.ex:229: Kernel.Typespec.translate_typespecs_for_module/2
    (elixir 1.10.1) src/elixir_erl_compiler.erl:12: anonymous fn/3 in :elixir_erl_compiler.spawn/2
could not compile dependency :inky, "mix compile" failed. You can recompile this dependency with "mix deps.compile inky", update it with "mix deps.update inky" or clean it with "mix deps.clean inky"
```