### PR TITLE
Correct height for PhatSSD1608 and do minor refactoring

### DIFF
--- a/lib/display/display.ex
+++ b/lib/display/display.ex
@@ -20,11 +20,10 @@ defmodule Inky.Display do
   def spec_for(type, accent \\ :black)
 
   def spec_for(type = :phat_ssd1608, accent) do
-    # Keep it minimal. Details are specified in `Inky.HAL.PhatSSD1608`.
     %__MODULE__{
       type: type,
       width: 250,
-      height: 122,
+      height: 136,
       packed_dimensions: %{},
       rotation: -90,
       accent: accent,


### PR DESCRIPTION
The height value was wrong in one location for SSD1608.

In the [Python library](https://github.com/pimoroni/inky/blob/fc17026df35447c1147e9bfa38988e89e75c80e6/library/inky/inky_ssd1608.py#L29), there are two sets of dimensions for SSD1608, which is confusing. but it seems like `250x136` works better in our code than `250x122`.

Also I moved the display info from`Inky.HAL.PhatSSD1608` to`Inky.Display` struct. I think it makes SSD1608 code slightly more consistent with the other code.

### Notes

- The Python library uses [`PIL`] and [`numpy`] to offset the image [here](https://github.com/pimoroni/inky/blob/fc17026df35447c1147e9bfa38988e89e75c80e6/library/inky/inky_ssd1608.py#L258-L260) but I do not know what is the equivalent in Elixir.
- We might need some more fine-tuning, but as of this PR the image is at least centered and there is no extra space at the top. I'd say this is good enough if it is not perfect.

[`PIL`]: https://pillow.readthedocs.io/en/stable/
[`numpy`]: https://numpy.org/