### PR TITLE
Mention Inky.EEPROM.read/0 in readme and improve Display typespec

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ is in the works, check it out, to follow how it is progressing.
 Inky is available on Hex. Add inky to your mix.exs deps:
 
 ```elixir
-{:inky, "~> 1.0.1"},
+{:inky, "~> 1.0.2"},
 ```
 
 Run `mix deps.get` to get the new dep.
@@ -37,6 +37,27 @@ Run `mix deps.get` to get the new dep.
 A sample for Inky only, both host development and on-device is available as [pappersverk/sample_inky](https://github.com/pappersverk/sample_inky).
 
 A sample for using it with Scenic both for host development and on-device is available as [pappersverk/sample_scenic_inky](https://github.com/pappersverk/sample_scenic_inky).
+
+There are multiple variants of wHAT, pHAT, etc, and they are hard to distinguish.
+You can read the display information from your Inky's EEPROM by invoking `Inky.EEPROM.read/0`.
+
+```elixir
+iex> Inky.EEPROM.read()
+{:ok,
+%Inky.EEPROM{
+  color: :red,
+  display_variant: "Red pHAT (SSD1608)",
+  height: 104,
+  pcb_variant: 12,
+  timestamp: "2021-03-30 08:58:28.9",
+  width: 212
+}}
+```
+
+Particularly the display variant gives you a clue what type of Inky you are
+using, based on which you will determine the options for `Inky.start_link/3`.
+
+`Inky.EEPROM.read/0` works only one time after the display is powered on.
 
 ## Brief example
 
@@ -63,5 +84,5 @@ end
 Inky.set_pixels(InkySample, painter, border: :white)
 
 # Flip a few pixels
-Inky.set_pixels(pid, %{{0,0}: :black, {3,49}: :red, {23, 4}: white})
+Inky.set_pixels(pid, %{{0, 0} => :black, {3, 49} => :red, {23, 4} => :white})
 ```

--- a/lib/display/display.ex
+++ b/lib/display/display.ex
@@ -6,6 +6,8 @@ defmodule Inky.Display do
   alias Inky.LookupTables
 
   @type t() :: %__MODULE__{}
+  @type variant :: :phat | :phat_ssd1608 | :what
+  @type accent :: :black | :red | :yellow
 
   @enforce_keys [:type, :width, :height, :packed_dimensions, :rotation, :accent, :luts]
   defstruct type: nil,
@@ -16,7 +18,7 @@ defmodule Inky.Display do
             accent: :black,
             luts: <<>>
 
-  @spec spec_for(:phat_ssd1608 | :phat | :what, :black | :red | :yellow) :: Inky.Display.t()
+  @spec spec_for(variant(), accent()) :: Inky.Display.t()
   def spec_for(type, accent \\ :black)
 
   def spec_for(type = :phat_ssd1608, accent) do

--- a/lib/inky.ex
+++ b/lib/inky.ex
@@ -54,6 +54,7 @@ defmodule Inky do
 
   See `GenServer.start_link/3` for return values.
   """
+  @spec start_link(Inky.Display.variant(), Inky.Display.accent(), map()) :: GenServer.on_start()
   def start_link(type, accent, opts \\ %{}) do
     genserver_opts = if(opts[:name], do: [name: opts[:name]], else: [])
     GenServer.start_link(__MODULE__, [type, accent, opts], genserver_opts)


### PR DESCRIPTION
This is a minor enhancement.

- Mention `Inky.EEPROM.read/0` in readme 
- Add types to `Inky.Display`
  - `variant` 
  - `color`
- correct Elixir syntax in the last line of the "Brief example"