### PR TITLE
Correct dimensions from EEPROM

### DIFF
--- a/lib/display/eeprom.ex
+++ b/lib/display/eeprom.ex
@@ -56,14 +56,15 @@ defmodule Inky.EEPROM do
     end
   end
 
-  # The data might look like this:
-  #
-  #   <<212, 0, 104, 0, 1, 12, 10, 21, 50, 48, 50, 49, 45, 48, 55, 45, 49, 50, 32, 49, 48, 58, 49, 49, 58, 52, 57, 46, 56>>
-  #
-  defp parse_data(
-         <<width, _, height, _, color, pcb_variant, display_variant, _, timestamp::binary>>
-       )
-       when color in 0..5 and display_variant in 0..14 do
+  @doc """
+  Parses data from Inky's EEPROM.
+  """
+  @spec parse_data(<<_::232>>) :: {:ok, t()} | {:error, {:invalid_data, any()}}
+  def parse_data(
+        <<width::little-16, height::little-16, color, pcb_variant, display_variant, _,
+          timestamp::binary>>
+      )
+      when color in 0..5 and display_variant in 0..14 do
     {:ok,
      __struct__(
        width: width,
@@ -75,7 +76,7 @@ defmodule Inky.EEPROM do
      )}
   end
 
-  defp parse_data(data) do
+  def parse_data(data) do
     {:error, {:invalid_data, data}}
   end
 end

--- a/test/eeprom_test.exs
+++ b/test/eeprom_test.exs
@@ -1,0 +1,40 @@
+defmodule Inky.EEPROMTest do
+  @moduledoc false
+
+  use ExUnit.Case
+  import Inky.EEPROM
+
+  describe "parse_data/1" do
+    test "returns correct struct for Inky pHAT SSD1608" do
+      inky_ssd1608_eeprom =
+        <<212, 0, 104, 0, 1, 12, 10, 21, 50, 48, 50, 49, 45, 48, 55, 45, 49, 50, 32, 49, 48, 58,
+          49, 49, 58, 52, 57, 46, 56>>
+
+      assert {:ok,
+              %Inky.EEPROM{
+                color: :black,
+                display_variant: "Black pHAT (SSD1608)",
+                height: 104,
+                pcb_variant: 12,
+                timestamp: "2021-07-12 10:11:49.8",
+                width: 212
+              }} = parse_data(inky_ssd1608_eeprom)
+    end
+
+    test "returns correct struct for Inky Impression" do
+      inky_impression_eeprom =
+        <<88, 2, 192, 1, 0, 12, 14, 21, 50, 48, 50, 49, 45, 48, 56, 45, 50, 53, 32, 49, 55, 58,
+          49, 50, 58, 49, 48, 46, 51>>
+
+      assert {:ok,
+              %Inky.EEPROM{
+                color: :unknown,
+                display_variant: "7-Color (UC8159)",
+                height: 448,
+                pcb_variant: 12,
+                timestamp: "2021-08-25 17:12:10.3",
+                width: 600
+              }} = parse_data(inky_impression_eeprom)
+    end
+  end
+end


### PR DESCRIPTION
I found a bug in the data parsing code I wrote in https://github.com/pappersverk/inky/pull/39. Width and height are supposed to be `little-16`, but current logic only reads low 8 bits. Those values become wrong when they are greater than 255.