### PR TITLE
Impression

### DIFF
--- a/lib/display/display.ex
+++ b/lib/display/display.ex
@@ -28,7 +28,6 @@ defmodule Inky.Display do
       height: height,
       packed_resolution:
         <<width::unsigned-big-integer-size(16)>> <> <<height::unsigned-big-integer-size(16)>>,
-      packed_dimensions: packed_dimensions(type, width, height),
       rotation: 0,
       accent: nil
     }
@@ -84,7 +83,6 @@ defmodule Inky.Display do
       case type do
         :what -> width
         :phat -> height
-        :impression -> width
         :test_small -> height
       end
 
@@ -95,7 +93,6 @@ defmodule Inky.Display do
     rows =
       case type do
         :what -> height
-        :impression -> height
         :phat -> width
         :test_small -> width
       end

--- a/lib/display/display.ex
+++ b/lib/display/display.ex
@@ -19,13 +19,18 @@ defmodule Inky.Display do
 
   @spec spec_for(:impression) :: Inky.Display.t()
   def spec_for(type = :impression) do
+    width = 600
+    height = 448
+
     %__MODULE__{
       type: type,
-      width: 600,
-      height: 448,
-      packed_resolution: <<2, 88, 1, 192>>, # I used the struct.pack in Python to generate this
+      width: width,
+      height: height,
+      packed_resolution:
+        <<width::unsigned-big-integer-size(16)>> <> <<height::unsigned-big-integer-size(16)>>,
+      packed_dimensions: packed_dimensions(type, width, height),
       rotation: 0,
-      accent: nil,
+      accent: nil
     }
   end
 

--- a/lib/display/display.ex
+++ b/lib/display/display.ex
@@ -84,6 +84,7 @@ defmodule Inky.Display do
       case type do
         :what -> width
         :phat -> height
+        :impression -> width
         :test_small -> height
       end
 
@@ -94,6 +95,7 @@ defmodule Inky.Display do
     rows =
       case type do
         :what -> height
+        :impression -> height
         :phat -> width
         :test_small -> width
       end

--- a/lib/display/pixelutil.ex
+++ b/lib/display/pixelutil.ex
@@ -3,7 +3,7 @@ defmodule Inky.PixelUtil do
   PixelUtil maps pixels to bitstrings to be sent to an Inky screen
   """
 
-  def pixels_to_bits(pixels, width, height, rotation_degrees, color_map) do
+  def pixels_to_bits(pixels, width, height, rotation_degrees, color_map, bit_size \\ 1) do
     {outer_axis, dimension_vectors} =
       rotation_degrees
       |> normalised_rotation()
@@ -13,7 +13,8 @@ defmodule Inky.PixelUtil do
     |> rotated_ranges(width, height)
     |> do_pixels_to_bits(
       &pixels[pixel_key(outer_axis, &1, &2)],
-      &(color_map[&1] || color_map.miss)
+      &(color_map[&1] || color_map.miss),
+      bit_size
     )
   end
 
@@ -61,10 +62,10 @@ defmodule Inky.PixelUtil do
   defp rotated_dimension(_width, height, {:y, 1}), do: 0..(height - 1)
   defp rotated_dimension(_width, height, {:y, -1}), do: (height - 1)..0
 
-  defp do_pixels_to_bits({i_range, j_range}, pixel_picker, cmap) do
+  defp do_pixels_to_bits({i_range, j_range}, pixel_picker, cmap, bit_size) do
     for i <- i_range,
         j <- j_range,
-        do: <<cmap.(pixel_picker.(i, j))::size(1)>>,
+        do: <<cmap.(pixel_picker.(i, j))::size(bit_size)>>,
         into: <<>>
   end
 

--- a/lib/hal/impression/rpihal.ex
+++ b/lib/hal/impression/rpihal.ex
@@ -132,7 +132,7 @@ defmodule Inky.Impression.RpiHAL do
     display = %Display{width: w, height: h, rotation: r} = state.display
     Logger.info("display: #{inspect(display)}")
     IO.puts("Generating buffer...")
-    buffer = PixelUtil.pixels_to_bits(pixels, w, h, r, @color_map)
+    buffer = PixelUtil.pixels_to_bits(pixels, w, h, r, @color_map, 4)
     log("Resetting device")
     reset(state)
 

--- a/lib/hal/impression/rpihal.ex
+++ b/lib/hal/impression/rpihal.ex
@@ -9,6 +9,7 @@ defmodule Inky.Impression.RpiHAL do
 
   @behaviour Inky.HAL
 
+  @color_map %{black: 0, white: 1, green: 2, blue: 3, red: 4, yellow: 5, orange: 6, miss: 1}
   @colors %{
     :black => 0,
     :white => 1,
@@ -172,7 +173,7 @@ defmodule Inky.Impression.RpiHAL do
   defp do_update(state, display, border, buffer) do
     IO.inspect(buffer, label: "buffer (rpihal.ex:138)")
     Logger.info("border: #{inspect(border)}")
-    border = :red
+    border = :black
     d_pd = display.packed_dimensions
 
     state

--- a/lib/hal/impression/rpihal.ex
+++ b/lib/hal/impression/rpihal.ex
@@ -21,32 +21,72 @@ defmodule Inky.Impression.RpiHAL do
     :clean => 7
   }
 
+  # PANEL SETTING
   @psr 0x00
+  # POWER SETTING
   @pwr 0x01
+  # POWER OFF
   @pof 0x02
+  # POWER OFF SEQUENCE SETTING
   @pfs 0x03
+  # POWER ON
   @pon 0x04
   @btst 0x06
   @dslp 0x07
+  # DATA START TRANSMISSION 1
   @dtm1 0x10
+  # TODO: Why are we not using the data stop command?
+  # DATA STOP
   @dsp 0x11
+  # DISPLAY REFRESH
   @drf 0x12
   @ipc 0x13
+  # PLL (Phased Lock Loop) CONTROL
+  # https://en.wikipedia.org/wiki/Phase-locked_loop
   @pll 0x30
+  # TEMPERATURE SENSOR CALIBRATION
+  # This command reads the temperature sensed by the temperature sensor.
   @tsc 0x40
+  # TEMPERATURE SENSOR CALIBRATION
+  # This command selects Internal or External temperature sensor.
   @tse 0x41
   @tws 0x42
   @tsr 0x43
+  # VCOM AND DATA INTERVAL SETTING
+  # This command indicates the interval of Vcom and data output. When setting
+  # the vertical back porch, the total blanking will be kept (20 Hsync).
   @cdi 0x50
+  # LOW POWER DETECTION
+  # This command indicates the input power condition. Host can read this flag to learn the battery condition.
   @lpd 0x51
+  # TCON SETTING
+  # This command defines non-overlap period of Gate and Source.
   @tcon 0x60
+  # RESOLUTION SETTING  (TRES)
+  # This command defines alternative resolution and this setting is of higher priority than the RES[1:0] in R00H (PSR).
   @tres 0x61
+  # SPI FLASH CONTROL
+  # This command defines MCU host direct access external memory mode.
+  # This might allow us to specify our own lookup tables! Which might mean our own colors!
   @dam 0x65
+  # REVISION
+  # The REV is read from OTP address = 0x001
   @rev 0x70
+  # GET STATUS
+  # This command reads the IC status.
+  # I2C?
   @flg 0x71
+  # AUTO MEASURE VCOM
+  # This command reads the IC status.
   @amv 0x80
+  # VCOM VALUE
+  # This command gets the Vcom value.
   @vv 0x81
+  # VCM_DC SETTING
+  # This command sets VCOM_DC value.
   @vdcs 0x82
+  # WARN: Not found in datasheet
+  # python driver calls it "UC8159_7C"
   @pws 0xE3
   @tsset 0xE5
 

--- a/lib/hal/impression/rpihal.ex
+++ b/lib/hal/impression/rpihal.ex
@@ -176,7 +176,7 @@ defmodule Inky.Impression.RpiHAL do
     Logger.info(msg)
   end
 
-  defp log(_state, msg) when is_binary(msg) do
+  defp log(state, msg) when is_binary(msg) do
     IO.puts(msg)
     Logger.info(msg)
     state

--- a/lib/hal/impression/rpihal.ex
+++ b/lib/hal/impression/rpihal.ex
@@ -132,20 +132,7 @@ defmodule Inky.Impression.RpiHAL do
     Logger.info("display: #{inspect(display)}")
     IO.puts("Generating buffer...")
 
-    buffer =
-      for y <- 0..(h - 1), x <- 0..(w - 1), into: <<>> do
-        cond do
-          x > 150 && y > 200 -> <<@colors[:orange]>>
-          x > 100 -> <<@colors[:blue]>>
-          y > 100 -> <<@colors[:green]>>
-          true -> <<rem(y, @colors[:orange] + 1)>>
-        end
-        # color = floor(0 / w * 7)
-      end
-
-    log("Generated buffer of size: #{byte_size(buffer)}")
-    log("buffer: #{inspect(buffer)}")
-
+    buffer = PixelUtil.pixels_to_bits(pixels, w, h, r, @color_map)
     log("Resetting device")
     reset(state)
 

--- a/lib/hal/impression/rpihal.ex
+++ b/lib/hal/impression/rpihal.ex
@@ -132,10 +132,11 @@ defmodule Inky.Impression.RpiHAL do
     display = %Display{width: w, height: h, rotation: r} = state.display
     Logger.info("display: #{inspect(display)}")
     IO.puts("Generating buffer...")
-
     buffer = PixelUtil.pixels_to_bits(pixels, w, h, r, @color_map)
     log("Resetting device")
     reset(state)
+    # Note: soft_reset doesn't perform any differently than reset
+    # soft_reset(state)
 
     case pre_update(state, push_policy) do
       :cont -> do_update(state, display, border, buffer)
@@ -171,7 +172,6 @@ defmodule Inky.Impression.RpiHAL do
   end
 
   defp do_update(state, display, border, buffer) do
-    IO.inspect(buffer, label: "buffer (rpihal.ex:138)")
     Logger.info("border: #{inspect(border)}")
     border = :black
     d_pd = display.packed_dimensions
@@ -258,6 +258,10 @@ defmodule Inky.Impression.RpiHAL do
   # 0b00000010 = DC-DC converter, 0 = off, 1 = on
   # 0b00000001 = Soft reset, 0 = Reset, 1 = Normal (Default)
   defp set_panel(state), do: write_command(state, @psr, [0b11101111, 0x08])
+  # NOTE: Tried several alternatives below
+  # defp set_panel(state), do: write_command(state, @psr, [Bitwise.<<<(0b11, 6), 0x08])
+  # defp set_panel(state), do: write_command(state, @psr, [0b11000000, 0x08])
+  # TODO: Figure out how panel workks and whether it needs adjustment.
 
   defp set_power(state),
     do:

--- a/lib/hal/impression/rpihal.ex
+++ b/lib/hal/impression/rpihal.ex
@@ -186,10 +186,13 @@ defmodule Inky.Impression.RpiHAL do
     IO.inspect(buffer, label: "buffer (rpihal.ex:138)")
     Logger.info("border: #{inspect(border)}")
     border = :red
+    d_pd = display.packed_dimensions
 
     state
     |> log("setting resolution")
     |> set_resolution(display.packed_resolution)
+    |> log("setting dimensions")
+    |> set_dimensions(d_pd.width, d_pd.height)
     |> log("setting panel")
     |> set_panel()
     |> log("setting power")
@@ -227,6 +230,17 @@ defmodule Inky.Impression.RpiHAL do
     |> log("done")
 
     {:ok, %State{state | setup?: true}}
+  end
+
+  defp set_dimensions(state, width_data, packed_height) do
+    height_data = <<0, 0>> <> packed_height
+    width_data = <<0>> <> width_data
+
+    state
+    # Set RAM X Start/End
+    |> write_command(0x44, width_data)
+    # Set RAM Y Start/End
+    |> write_command(0x45, height_data)
   end
 
   #

--- a/lib/hal/impression/rpihal.ex
+++ b/lib/hal/impression/rpihal.ex
@@ -243,7 +243,7 @@ defmodule Inky.Impression.RpiHAL do
 
   defp soft_reset(state), do: write_command(state, 0x12)
 
-  # >HH struct.pack, so big-endian, unsigned-sort * 2
+  # >HH struct.pack, so big-endian, unsigned-short * 2
   defp set_resolution(state, packed_resolution),
     do: write_command(state, @tres, packed_resolution)
 

--- a/lib/inky.ex
+++ b/lib/inky.ex
@@ -41,7 +41,7 @@ defmodule Inky do
     {:ok, pid} = Inky.start_link(:impression, name: Inky.Foo)
     IO.puts("Started... #{inspect(pid)}")
 
-    IO.puts("Seting pixels...")
+    IO.puts("Setting pixels...")
     Inky.set_pixels(Inky.Foo, %{})
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -7,7 +7,7 @@ defmodule Inky.MixProject do
       version: "1.0.2",
       elixir: "~> 1.8",
       start_permanent: Mix.env() == :prod,
-      source_url: "https://github.com/jasonmj/inky/",
+      source_url: "https://github.com/pappersverk/inky/",
       deps: deps(),
       docs: docs(),
       package: package()
@@ -26,7 +26,7 @@ defmodule Inky.MixProject do
     [
       # {:circuits_gpio, "~> 1.0"},
       {:circuits_gpio, "~> 0.4"},
-      {:circuits_spi, "~> 1.0", override: true},
+      {:circuits_spi, "~> 1.0"},
       {:credo, "~> 1.0.0", only: [:dev, :test], runtime: false},
       {:ex_doc, ">= 0.0.0", only: :dev}
     ]
@@ -49,7 +49,7 @@ defmodule Inky.MixProject do
       description:
         "A library to drive the Inky series of eInk displays from Pimoroni. Ported from the original Python project, all Elixir.",
       licenses: ["Apache-2.0"],
-      links: %{"GitHub" => "https://github.com/jasonmj/inky"}
+      links: %{"GitHub" => "https://github.com/pappersverk/inky"}
     ]
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -7,7 +7,7 @@ defmodule Inky.MixProject do
       version: "1.0.2",
       elixir: "~> 1.8",
       start_permanent: Mix.env() == :prod,
-      source_url: "https://github.com/pappersverk/inky/",
+      source_url: "https://github.com/jasonmj/inky/",
       deps: deps(),
       docs: docs(),
       package: package()
@@ -26,7 +26,7 @@ defmodule Inky.MixProject do
     [
       # {:circuits_gpio, "~> 1.0"},
       {:circuits_gpio, "~> 0.4"},
-      {:circuits_spi, "~> 1.0"},
+      {:circuits_spi, "~> 1.0", override: true},
       {:credo, "~> 1.0.0", only: [:dev, :test], runtime: false},
       {:ex_doc, ">= 0.0.0", only: :dev}
     ]
@@ -49,7 +49,7 @@ defmodule Inky.MixProject do
       description:
         "A library to drive the Inky series of eInk displays from Pimoroni. Ported from the original Python project, all Elixir.",
       licenses: ["Apache-2.0"],
-      links: %{"GitHub" => "https://github.com/pappersverk/inky"}
+      links: %{"GitHub" => "https://github.com/jasonmj/inky"}
     ]
   end
 end


### PR DESCRIPTION
Adding my WIP commits to add scenic support for the inky impression. I was able to get the screen to load _something_ through scenic: 
![image](https://user-images.githubusercontent.com/1964622/177054647-6059ecc4-1c96-46b7-9202-4c24d0e4072c.png)

In order to do this, I needed to fork and update the pappersverk/scenic_driver_inky repo with a few [changes to accomodate the impression](https://github.com/pappersverk/scenic_driver_inky/compare/master...jasonmj:scenic_driver_inky:support-inky-impression). My work toward supporting the impression has occurred on a [fork of inky](https://github.com/jasonmj/inky) on the impression branch. 

Unfortunately, I'm stuck at a point where the output appears at 1/4 the size it should be and 4X across the screen. I've pushed my test project to https://github.com/jasonmj/impression where the `inky` and `scenic_driver_inky` deps are set to my forks.

Aiming to catch up with @axelson about it soon. See comments in code and on GitHub for more details.